### PR TITLE
Changing cancelParticipantPayments() to a public static function

### DIFF
--- a/CRM/Eventbrite/WebhookProcessor/Attendee.php
+++ b/CRM/Eventbrite/WebhookProcessor/Attendee.php
@@ -348,7 +348,7 @@ class CRM_Eventbrite_WebhookProcessor_Attendee extends CRM_Eventbrite_WebhookPro
     $this->cancelParticipantPayments($participantId);
   }
 
-  private function cancelParticipantPayments($participantId) {
+  public static function cancelParticipantPayments($participantId) {
     $participantPayments = _eventbrite_civicrmapi('participantPayment', 'get', array(
       'participant_id' => $participantId,
     ), "Processing Attendee {$this->entityId}, attempting to get existing contribution.");

--- a/CRM/Eventbrite/WebhookProcessor/Attendee.php
+++ b/CRM/Eventbrite/WebhookProcessor/Attendee.php
@@ -196,7 +196,7 @@ class CRM_Eventbrite_WebhookProcessor_Attendee extends CRM_Eventbrite_WebhookPro
 
     // If participant status is canceled, also cancel the payment record.
     if ($apiParams['participant_status'] == 'Cancelled') {
-      $this->cancelParticipantPayments($participant['id']);
+      self::cancelParticipantPayments($participant['id']);
     }
   }
 
@@ -345,7 +345,7 @@ class CRM_Eventbrite_WebhookProcessor_Attendee extends CRM_Eventbrite_WebhookPro
       'id' => $participantId,
       'participant_status' => 'Removed_in_EventBrite',
     ), "Processing Participant {$participantId}, attempting to mark participant as 'Removed in Eventbrite'.");
-    $this->cancelParticipantPayments($participantId);
+    self::cancelParticipantPayments($participantId);
   }
 
   public static function cancelParticipantPayments($participantId) {

--- a/CRM/Eventbrite/WebhookProcessor/Attendee.php
+++ b/CRM/Eventbrite/WebhookProcessor/Attendee.php
@@ -351,12 +351,12 @@ class CRM_Eventbrite_WebhookProcessor_Attendee extends CRM_Eventbrite_WebhookPro
   public static function cancelParticipantPayments($participantId) {
     $participantPayments = _eventbrite_civicrmapi('participantPayment', 'get', array(
       'participant_id' => $participantId,
-    ), "Processing Attendee {$this->entityId}, attempting to get existing contribution.");
+    ), "Processing Participant {$participantId}, attempting to get existing contribution.");
     foreach ($participantPayment['values'] as $value) {
       _eventbrite_civicrmapi('contribution', 'create', array(
         'id' => $value['contribution_id'],
         'contribution_status_id' => 'cancelled',
-      ), "Processing Attendee {$this->entityId}, attempting to get cancel existing contribution.");
+        ), "Processing Participant {$participantId}, attempting to get existing contribution.");
     }
   }
 


### PR DESCRIPTION
This will fix a fatal error that occurs if someone changes the name of an EB attendee, and the sync looks for the participant record on the wrong contact record.