### PR TITLE
Fix the webhook URL for WordPress

### DIFF
--- a/CRM/Eventbrite/Utils.php
+++ b/CRM/Eventbrite/Utils.php
@@ -7,7 +7,19 @@
  */
 class CRM_Eventbrite_Utils {
   static public function getWebhookListenerUrl() {
-    return CRM_Utils_System::url('civicrm/eventbrite/webhook', NULL, TRUE);
+    $url = CRM_Utils_System::url('civicrm/eventbrite/webhook',
+      NULL,
+      TRUE,
+      NULL,
+      FALSE,
+      FALSE,
+      FALSE);
+    if (strpos($url, 'wp-admin/admin.php') !== FALSE) {
+      Civi::log()->info("Eventbrite: fix URL for WordPress");
+      $url = str_replace('/wp-admin/admin.php', '', $url);
+    }
+    Civi::log()->info("Eventbrite webhook url: " . $url);
+    return $url;
   }
 
 }


### PR DESCRIPTION
The callback URL generated by `CRM_Utils_System::url` is wrong. Here is a fix for WordPress.

Before
-------
When using WordPress, the URL sent to webhook is `[yoursite.com]/wp-admin/admin.php?page=CiviCRM&amp;q=civicrm%2Feventbrite%2Fwebhook`.

After
-------
The URL will be `[yoursite.com]?page=CiviCRM&q=civicrm%2Feventbrite%2Fwebhook`.

Comment
-------
Apparently, `CRM_Utils_System::url` cannot generate a correct frontend URL for WordPress even if I set the `frontend` parameter to `TRUE` (I got `[yoursite.com]/civicrm?page=CiviCRM&q=civicrm%2Feventbrite%2Fwebhook`).

I don't think this the best solution, so feel free to improve it.

Agileware ref: CIVICRM-1278